### PR TITLE
Added support for passing a retention policy for measurements

### DIFF
--- a/octoprint_influxdb/__init__.py
+++ b/octoprint_influxdb/__init__.py
@@ -159,6 +159,7 @@ class InfluxDBPlugin(octoprint.plugin.EventHandlerPlugin,
 			if self.influx_db:
 				self.influx_kwargs = kwargs
 				self.influx_prefix = self._settings.get(['prefix']) or ''
+				self.influx_retention_policy = self._settings.get(['retention_policy']) or None
 
 		# start a new timer
 		if self.influx_db:
@@ -208,7 +209,7 @@ class InfluxDBPlugin(octoprint.plugin.EventHandlerPlugin,
 			'fields': fields,
 		}
 		try:
-			self.influx_db.write_points([point])
+			self.influx_db.write_points([point], retention_policy=self.influx_retention_policy)
 		except Exception:
 			# we were dropped! try to reconnect
 			self.influx_flash_exception("Disconnected from InfluxDB. Attempting to reconnect.")
@@ -320,7 +321,7 @@ class InfluxDBPlugin(octoprint.plugin.EventHandlerPlugin,
 			hostcustom='octoprint',
 			username=None,
 			password=None,
-
+			retention_policy=None,
 			interval=1,
 		)
 

--- a/octoprint_influxdb/templates/influxdb_settings.jinja2
+++ b/octoprint_influxdb/templates/influxdb_settings.jinja2
@@ -35,6 +35,16 @@
 
     <br>
 
+    <label class="control-label">{{ _('Retention Policy') }}</label>
+    <div class="controls">
+      <input type="text" class="input-medium" placeholder="None" data-bind="value: settings.plugins.influxdb.retention_policy">
+      <span class="help-block">
+        {{ _('If not specified the default policy of None will be used. The retention policy must be created on the database before setting this value.') }}
+      </span>
+    </div>
+
+    <br>
+
     <label class="control-label">{{ _('Prefix') }}</label>
     <div class="controls">
       <input type="text" class="input-medium" placeholder="(no prefix)" data-bind="value: settings.plugins.influxdb.prefix">
@@ -42,7 +52,7 @@
         {{ _('Measurement names will be prefixed by this string. Helpful when sharing a database.') }}
       </span>
     </div>
-
+    
     <label class="control-label">{{ _('%(host)s Tag', host='<tt>host</tt>') }}</label>
     <div class="controls">
       <label class="radio">


### PR DESCRIPTION
Implemented the ability to pass a retention policy for measurements being sent to InfluxDB.

The functionality added will use the default retention policy value of "None" when no retention policy value is specified retaining the normal behavior of the plugin. The functionality will not create the retention policy if it does not exist. The retention policy must be created on the database before setting a value on the plugin settings page. As it stands I opted to not to have it create retention policies automatically as everyone will have different needs behind what their retention policy should be.

The plugin was tested against OctoPrint 1.4.2 and Python 2.7.16 running on a Raspberry Pi 4 GB model. The InfluxDB server was running version 1.8. 

The installation method used was the command below:
```
# /home/pi/oprint/bin/python -m pip --disable-pip-version-check install --no-cache-dir https://github.com/directionalpad/OctoPrint-InfluxDB/archive/feature/retention_policies.zip
```

Feedback and criticism are welcome on this merge request. 